### PR TITLE
Replace undefined/null with empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,18 @@
 var escapeHtml = require('xml-escape'),
     mustaches = /(\{\{ *([a-zA-Z0-9$_]+) *\}\})|(\{\{\{ *([a-zA-Z0-9$_]+) *\}\}\})/g;
 
+function prop(key, context) {
+    var value = context.hasOwnProperty(key) ? context[key] : '';
+    if (value === undefined || value === null) { return ''; }
+    return String(value);
+}
+
 module.exports = function(template) {
     return function(context) {
         return template.replace(mustaches, function(matches, $1, $2, $3, $4) {
             var key = $2 || $4,
                 escape = Boolean($2),
-                value = context.hasOwnProperty(key) ? String(context[key]) : '';
+                value = prop(key, context);
 
             if (value && escape) { return escapeHtml(value); }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -54,6 +54,26 @@ test('{{ escaped strings }}', function(assert) {
             input: '{{foo}}',
             context: { foo: 1 },
             expected: '1'
+        },
+        {
+            input: '{{foo}}',
+            context: { foo: undefined },
+            expected: ''
+        },
+        {
+            input: '{{foo}}',
+            context: { foo: null },
+            expected: ''
+        },
+        {
+            input: '{{foo}}',
+            context: { foo: false },
+            expected: 'false'
+        },
+        {
+            input: '{{foo}}',
+            context: { foo: true },
+            expected: 'true'
         }
     ];
 
@@ -118,6 +138,26 @@ test('{{{ unescaped strings }}}', function(assert) {
             input: '{{{foo}}}',
             context: { foo: 1 },
             expected: '1'
+        },
+        {
+            input: '{{{foo}}}',
+            context: { foo: undefined },
+            expected: ''
+        },
+        {
+            input: '{{{foo}}}',
+            context: { foo: null },
+            expected: ''
+        },
+        {
+            input: '{{{foo}}}',
+            context: { foo: false },
+            expected: 'false'
+        },
+        {
+            input: '{{{foo}}}',
+            context: { foo: true },
+            expected: 'true'
         }
     ];
 


### PR DESCRIPTION
Replace values of `undefined` and `null` with an empty string rather
than the strings "undefined" and "null". This is consistent with
mustache and Handlebars.
